### PR TITLE
fix(filtered_pagination): backport cosmos-sdk PR 11408; fixes off-by-one pagination issue

### DIFF
--- a/types/query/filtered_pagination.go
+++ b/types/query/filtered_pagination.go
@@ -102,7 +102,9 @@ func FilteredPaginate(
 		}
 
 		if numHits == end+1 {
-			nextKey = iterator.Key()
+			if nextKey == nil {
+				nextKey = iterator.Key()
+			}
 
 			if !countTotal {
 				break

--- a/types/query/filtered_pagination_test.go
+++ b/types/query/filtered_pagination_test.go
@@ -250,3 +250,66 @@ func execFilterPaginate(store sdk.KVStore, pageReq *query.PageRequest, appCodec 
 
 	return balResult, res, err
 }
+
+func (s *paginationTestSuite) TestFilteredPaginationsNextKey() {
+	app, ctx, appCodec := setupTest(s.T())
+
+	var balances sdk.Coins
+
+	for i := 1; i <= 10; i++ {
+		denom := fmt.Sprintf("test%ddenom", i)
+		balances = append(balances, sdk.NewInt64Coin(denom, int64(i)))
+	}
+
+	balances = balances.Sort()
+	addr1 := sdk.AccAddress([]byte("addr1"))
+	acc1 := app.AccountKeeper.NewAccountWithAddress(ctx, addr1)
+	app.AccountKeeper.SetAccount(ctx, acc1)
+	s.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addr1, balances))
+	store := ctx.KVStore(app.GetKey(types.StoreKey))
+
+	execFilterPaginate := func(store sdk.KVStore, pageReq *query.PageRequest, appCodec codec.Codec) (balances sdk.Coins, res *query.PageResponse, err error) {
+		balancesStore := prefix.NewStore(store, types.BalancesPrefix)
+		accountStore := prefix.NewStore(balancesStore, address.MustLengthPrefix(addr1))
+
+		var balResult sdk.Coins
+		res, err = query.FilteredPaginate(accountStore, pageReq, func(key []byte, value []byte, accumulate bool) (bool, error) {
+			var amount sdk.Int
+			err := amount.Unmarshal(value)
+			if err != nil {
+				return false, err
+			}
+
+			// filter odd amounts
+			if amount.Int64()%2 == 1 {
+				if accumulate {
+					balResult = append(balResult, sdk.NewCoin(string(key), amount))
+				}
+
+				return true, nil
+			}
+
+			return false, nil
+		})
+
+		return balResult, res, err
+	}
+
+	s.T().Log("verify next key of offset query")
+	pageReq := &query.PageRequest{Key: nil, Limit: 1, CountTotal: true}
+	balances, res, err := execFilterPaginate(store, pageReq, appCodec)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(1, len(balances))
+	s.Require().Equal(balances[0].Amount.Int64(), int64(1))
+	s.Require().Equal(uint64(5), res.Total)
+	s.Require().NotNil(res.NextKey)
+
+	pageReq = &query.PageRequest{Key: res.NextKey, Limit: 1}
+	balances, res, err = execFilterPaginate(store, pageReq, appCodec)
+	s.Require().NoError(err)
+	s.Require().NotNil(res)
+	s.Require().Equal(1, len(balances))
+	s.Require().Equal(balances[0].Amount.Int64(), int64(3))
+	s.Require().NotNil(res.NextKey)
+}


### PR DESCRIPTION
### Description

When pagination parameter CountTotal == true, FilteredPaginate() assumes that the end+1 record is NextKey. If the subsequent record (effectively end+2) is sparse (a no-hit, e.g. does not match the filtered criteria), numHits == end+1 is still true, leading to NextKey being set to the key beyond the end+1 hit. This results is subsequent queries using the NextKey (pagination.key) pointing to end+2, missing the end+1 record when delivering the subsequent page of results.

This PR backports a fix first introduced to cosmos-sdk v0.46.0-alpha4. See https://github.com/cosmos/cosmos-sdk/pull/11408 for context.

### Impacts/workarounds

The Terra Classic chain has frequently experienced this issue, most notably when the number of governance proposals in the voting state exceeds the current Terra Station pagination size (6), leading to active proposals being "skipped" when paging through record sets.

I have previously submitted PRs to Terra Station to work around this issue (see https://github.com/terra-money/station/pull/130). The workaround introduced requires an additional API call to first fetch the total number of records; subsequent calls then omit count_total to avoid this off-by-one bug when fetching the actual proposal records. Terra Station PR 130 is yet to merge into Terra Station, but fixing the underlying L1 issue will help cleanup the experience by eliminating this extra API call for Terra Station, as well as other clients that may be utilizing pagination.

### Summary of changes

This PR corrects the issue in types/query/filtered_pagination.go, function FilteredPaginate to only set nextKey if it is not already set. This ensures nextKey is set to end+1, and is not overwritten by subsequent no-hit records beyond end+1.
